### PR TITLE
Add replit run command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ Install dependencies and run `main.py`:
 
 ```bash
 pip install -r requirements.txt
-python main.py
+python3 main.py
 ```
 
 When you open the project in Replit, it will automatically install the packages
 listed in `requirements.txt`.
+Set the run command in Replit to:
+
+```
+python3 main.py
+```


### PR DESCRIPTION
## Summary
- update run instructions to use `python3`
- document the run command for Replit

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_684ca63c0d0c832b95fed3c927b7264c